### PR TITLE
clk-baikal: initialize clock early enough, and memory allocation fixes

### DIFF
--- a/drivers/clk/baikal/clk-baikal.c
+++ b/drivers/clk/baikal/clk-baikal.c
@@ -214,7 +214,7 @@ static long baikal_clk_round_rate(struct clk_hw *hw, unsigned long rate,
 	return res.a0;
 }
 
-const struct clk_ops be_clk_pll_ops = {
+static const struct clk_ops be_clk_pll_ops = {
 	.enable = baikal_clk_enable,
 	.disable = baikal_clk_disable,
 	.is_enabled = baikal_clk_is_enabled,

--- a/drivers/clk/baikal/clk-baikal.c
+++ b/drivers/clk/baikal/clk-baikal.c
@@ -240,10 +240,9 @@ static int __init baikal_clk_probe(struct device_node *node)
 	const char *clk_ch_name;
 	const char *parent_name;
 
-	cmu = kmalloc(sizeof(struct baikal_clk_cmu *), GFP_KERNEL);
+	cmu = kzalloc(sizeof(*cmu), GFP_KERNEL);
 	if (!cmu) {
 		pr_err("%s: could not allocate CMU clk\n", __func__);
-		kfree(cmu);
 		return -ENOMEM;
 	}
 

--- a/drivers/clk/baikal/clk-baikal.c
+++ b/drivers/clk/baikal/clk-baikal.c
@@ -223,13 +223,12 @@ const struct clk_ops be_clk_pll_ops = {
 	.round_rate = baikal_clk_round_rate,
 };
 
-static int  baikal_clk_probe(struct platform_device *pdev)
+static int __init baikal_clk_probe(struct device_node *node)
 {
 	struct clk_init_data init;
 	struct clk_init_data *init_ch;
 	struct baikal_clk_cmu *cmu;
 	struct baikal_clk_cmu **cmu_ch;
-	struct device_node *node = pdev->dev.of_node;
 
 	struct clk *clk;
 	struct clk_onecell_data *clk_ch;
@@ -357,38 +356,16 @@ static int  baikal_clk_probe(struct platform_device *pdev)
 			clk_prepare_enable(clk_ch->clks[index]);
 			i++;
 		}
-		return of_clk_add_provider(pdev->dev.of_node,
-					of_clk_src_onecell_get, clk_ch);
+		return of_clk_add_provider(node, of_clk_src_onecell_get, clk_ch);
 	}
 
-	return of_clk_add_provider(pdev->dev.of_node,
-				of_clk_src_simple_get, clk);
+	return of_clk_add_provider(node, of_clk_src_simple_get, clk);
 }
 
-static int baikal_clk_remove(struct platform_device *pdev)
-{
-	of_clk_del_provider(pdev->dev.of_node);
-
-	return 0;
+static void __init baikal_clk_init(struct device_node *np) {
+	int err = baikal_clk_probe(np);
+	if (err) {
+		panic("%s: failed to initialize clock: %d\n", __func__, err);
+	}
 }
-
-static const struct of_device_id baikal_clk_of_match[] =  {
-	{.compatible = "baikal,cmu"},
-	{ /* sentinel */ }
-};
-
-static struct platform_driver baikal_cmu_driver = {
-	.probe  = baikal_clk_probe,
-	.remove = baikal_clk_remove,
-	.driver = {
-		.name   = "baikal-cmu",
-		.of_match_table = baikal_clk_of_match,
-	},
-};
-
-module_platform_driver(baikal_cmu_driver);
-
-MODULE_DESCRIPTION("Baikal-M clock driver");
-MODULE_AUTHOR("Ekaterina Skachko <ekaterina.skachko@baikalelectronics.ru>");
-MODULE_LICENSE("GPL v2");
-MODULE_ALIAS("platform:baikal-cmu");
+CLK_OF_DECLARE_DRIVER(baikal_cmu, "baikal,cmu", baikal_clk_init);

--- a/drivers/clk/baikal/clk-baikal.c
+++ b/drivers/clk/baikal/clk-baikal.c
@@ -329,8 +329,12 @@ static int __init baikal_clk_probe(struct device_node *node)
 			init_ch[i].ops = &be_clk_pll_ops;
 			init_ch[i].flags = CLK_IGNORE_UNUSED;
 
-			cmu_ch[index] = kmalloc(sizeof(struct baikal_clk_cmu),
+			cmu_ch[index] = kzalloc(sizeof(struct baikal_clk_cmu),
 						GFP_KERNEL);
+			if (!cmu_ch[index]) {
+				pr_err("%s: could not allocate baikal_clk_cmu structure\n", __func__);
+				return -ENOMEM;
+			}
 			cmu_ch[index]->name = clk_ch_name;
 			cmu_ch[index]->cmu_id = index;
 			cmu_ch[index]->parent = cmu->cmu_id;


### PR DESCRIPTION
Currently clk-baikal gets initialized very late (after starting secondary CPUs, PCI-e init, etc).
This is wrong: clock driver should initialized much earlier. Use CLK_OF_DECLARE_DRIVER 
to ensure clock gets initialized/registered early enough

dmesg before:

```
[    1.063892] Asymmetric key parser 'x509' registered
[    1.069345] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
[    1.077756] io scheduler mq-deadline registered
[    1.082848] io scheduler bfq registered
[    1.087526] crc32: CRC_LE_BITS = 64, CRC_BE BITS = 64
[    1.093158] crc32: self tests passed, processed 225944 bytes in 184000 nsec
[    1.100987] crc32c: CRC_LE_BITS = 64
[    1.104969] crc32c: self tests passed, processed 225944 bytes in 29980 nsec
[    1.125936] crc32_combine: 8373 self tests passed
[    1.144367] crc32c_combine: 8373 self tests passed
[    1.152032] gpio-481 (pcie-x8-clock): hogged as output/high
[    1.159813] efifb: probing for efifb
[    1.164093] efifb: No BGRT, not showing boot graphics
[    1.169726] efifb: framebuffer at 0xfb1a6000, using 8100k, total 8100k
[    1.177005] efifb: mode is 1920x1080x32, linelength=7680, pages=1
[    1.183800] efifb: scrolling: redraw
[    1.187781] efifb: Truecolor: size=8:8:8:8, shift=24:16:8:0
[    1.194106] fbcon: Deferring console take-over
[    1.199068] fb0: EFI VGA frame buffer device
[    1.204451] baikal_clk_probe index 0 name <gpio> i 0 
[    1.210133] baikal_clk_probe index 1 name <uart1> i 1 
[    1.215903] baikal_clk_probe index 2 name <uart2> i 2 
[    1.221672] baikal_clk_probe index 3 name <apb> i 3 
[    1.227247] baikal_clk_probe index 4 name <spi> i 4 
[    1.232821] baikal_clk_probe index 5 name <espi> i 5 
[    1.238493] baikal_clk_probe index 6 name <i2c1> i 6 
[    1.244169] baikal_clk_probe index 7 name <i2c2> i 7 
[    1.249842] baikal_clk_probe index 8 name <timer1> i 8 
[    1.255710] baikal_clk_probe index 9 name <timer2> i 9 
[    1.261581] baikal_clk_probe index a name <timer3> i a 
[    1.267445] baikal_clk_probe index b name <timer4> i b 
[    1.273314] baikal_clk_probe index c name <dmac> i c 
[    1.278986] baikal_clk_probe index d name <smbus1> i d 
[    1.284853] baikal_clk_probe index e name <smbus2> i e 
[    1.290719] baikal_clk_probe index f name <hda_sys_clk> i f 
[    1.297069] baikal_clk_probe index 10 name <hda_clk48> i 10 
[    1.303423] baikal_clk_probe index 11 name <mshc_axi> i 11 
[    1.309678] baikal_clk_probe index 12 name <mshc_ahb> i 12 
[    1.315932] baikal_clk_probe index 13 name <mshc_tx_x2> i 13 
[    1.322380] baikal_clk_probe index 14 name <mshc_b> i 14 
[    1.328431] baikal_clk_probe index 15 name <mshc_tm> i 15 
[    1.334593] baikal_clk_probe index 16 name <mshc_cqetm> i 16 
[    1.341043] baikal_clk_probe index 17 name <hwa_clu> i 17 
[    1.347201] baikal_clk_probe index 18 name <hwa_clu_hf> i 18 
[    1.353651] baikal_clk_probe index 19 name <hwa_axi> i 19 
```

dmesg with patch:
```
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 768 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] GICv3: Distributor has no Range Selector support
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: 16 PPIs implemented
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000002d100000
[    0.000000] ITS [mem 0x2d020000-0x2d03ffff]
[    0.000000] ITS@0x000000002d020000: allocated 262144 Devices @880200000 (flat, esz 8, psz 64K, shr 0)
[    0.000000] ITS: using cache flushing for cmd queue
[    0.000000] GICv3: using LPI property table @0x0000000880170000
[    0.000000] GIC: using cache flushing for LPI property table
[    0.000000] GICv3: CPU0: using allocated LPI pending table @0x0000000880180000
[    0.000000] random: get_random_bytes called from start_kernel+0x7dc/0x9d0 with crng_init=0
[    0.000000] baikal_clk_probe index 0 name <gpio> i 0 
[    0.000000] baikal_clk_probe index 1 name <uart1> i 1 
[    0.000000] baikal_clk_probe index 2 name <uart2> i 2 
[    0.000000] baikal_clk_probe index 3 name <apb> i 3 
[    0.000000] baikal_clk_probe index 4 name <spi> i 4 
[    0.000000] baikal_clk_probe index 5 name <espi> i 5 
[    0.000000] baikal_clk_probe index 6 name <i2c1> i 6 
[    0.000000] baikal_clk_probe index 7 name <i2c2> i 7 
[    0.000000] baikal_clk_probe index 8 name <timer1> i 8 
[    0.000000] baikal_clk_probe index 9 name <timer2> i 9 
[    0.000000] baikal_clk_probe index a name <timer3> i a 
[    0.000000] baikal_clk_probe index b name <timer4> i b 
[    0.000000] baikal_clk_probe index c name <dmac> i c 
[    0.000000] baikal_clk_probe index d name <smbus1> i d 
[    0.000000] baikal_clk_probe index e name <smbus2> i e 
```